### PR TITLE
allow files in 'protos' 

### DIFF
--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -3,13 +3,13 @@
 %% @end
 %%%-------------------------------------------------------------------
 
-%% this module was generated on {{datetime}} and should not be modified manually
+%% this module was generated and should not be modified manually
 
 -module({{module_name}}_bhvr).
 
 {{#methods}}
-%% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
--callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:ctx(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
-    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:ctx()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
+%% {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
+-callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:t(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
+    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:t()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
 
 {{/methods}}

--- a/priv/grpcbox_service_client.erl
+++ b/priv/grpcbox_service_client.erl
@@ -3,7 +3,7 @@
 %% @end
 %%%-------------------------------------------------------------------
 
-%% this module was generated on {{datetime}} and should not be modified manually
+%% this module was generated and should not be modified manually
 
 -module({{module_name}}_client).
 

--- a/src/grpcbox_plugin_prv.erl
+++ b/src/grpcbox_plugin_prv.erl
@@ -1,7 +1,7 @@
 -module(grpcbox_plugin_prv).
 
 -export([init/1, do/1, format_error/1]).
--export([canonicalize_path/1]).
+
 -include_lib("providers/include/providers.hrl").
 
 -define(PROVIDER, gen).

--- a/src/grpcbox_plugin_prv.erl
+++ b/src/grpcbox_plugin_prv.erl
@@ -1,7 +1,7 @@
 -module(grpcbox_plugin_prv).
 
 -export([init/1, do/1, format_error/1]).
-
+-export([canonicalize_path/1]).
 -include_lib("providers/include/providers.hrl").
 
 -define(PROVIDER, gen).
@@ -62,7 +62,7 @@ handle_app(AppInfo, Options, State) ->
     GrpcOutDir = filename:join(BaseDir, GrpcOptOutDir),
     GpbOutDir = filename:join(BaseDir, proplists:get_value(o, GpbOpts, GrpcOptOutDir)),
 
-    ProtosDirs = case proplists:get_all_values(protos, Options) of
+    ProtosWilds = case proplists:get_all_values(protos, Options) of
                      [] ->
                          case proplists:get_value(protos, GrpcOpts, [filename:join("priv", "protos")]) of
                              [H | _] = Ds when is_list(H) ->
@@ -73,7 +73,9 @@ handle_app(AppInfo, Options, State) ->
                      Ds ->
                          Ds
                  end,
-    ProtoFiles = lists:append([filelib:wildcard(filename:join([BaseDir, D, "*.proto"])) || D <- ProtosDirs]),
+    rebar_log:log(debug, "Wilds ~p", [ProtosWilds]),
+    ProtoFiles = lists:flatmap(mk_expand_wilds(BaseDir), ProtosWilds),
+    rebar_log:log(debug, "Files ~p", [ProtoFiles]),
 
     Type = case proplists:get_value(type, Options, undefined) of
                undefined ->
@@ -87,6 +89,34 @@ handle_app(AppInfo, Options, State) ->
      || {ProtoModule, ProtoBeam} <- ProtoModules],
     ok.
 
+mk_expand_wilds(Basedir) ->
+    fun(Wild) -> expand_wild(Basedir, Wild) end.
+
+expand_wild(Basedir, Wild) ->
+    Path = canonicalize_path(filename:join(Basedir, Wild)),
+    rebar_log:log(debug, "Relative ~p", [{Wild, Basedir, Path}]),
+    case lists:suffix(".proto", Path) of
+        true -> filelib:wildcard(Path);
+        false -> filelib:wildcard(filename:join(Path, "*.proto"))
+    end.
+
+canonicalize_path(Path) ->
+    try "/"++string:join(fixup_path(Path), "/")
+    catch error:Err -> error({Err, Path})
+    end.
+
+fixup_path(Path) ->
+    case re:split(Path, "/", [{return, list}]) of
+        [""|Es] -> lists:reverse(lists:foldl(fun path_element/2, [], Es));
+        _ -> error(path_is_not_absolute)
+    end.
+
+path_element("..", []) -> error(path_is_unsafe);
+path_element("..", [_|Es]) -> Es;
+path_element(".", Es) -> Es;
+path_element("", Es) -> Es;
+path_element(E, Es) -> [E|Es].
+
 compile_pb(Filename, OutDir, BeamOutDir, GpbOpts) ->
     ModuleName = lists:flatten(
                    [proplists:get_value(module_name_prefix, GpbOpts, ""),
@@ -95,6 +125,7 @@ compile_pb(Filename, OutDir, BeamOutDir, GpbOpts) ->
     GeneratedPB = filename:join(OutDir, ModuleName ++ ".erl"),
     CompiledPB = filename:join(BeamOutDir, ModuleName ++ ".beam"),
     ok = filelib:ensure_dir(GeneratedPB),
+    ok = filelib:ensure_dir(CompiledPB),
     case needs_update(Filename, GeneratedPB) of
         true ->
             rebar_log:log(info, "Writing ~s", [GeneratedPB]),


### PR DESCRIPTION
As it is, the `protos` config can only contain directories. This PR allows one to specify files as well.
E.g.
`{protos, ["../../proto/bla/gw/*.proto"]}`